### PR TITLE
compile to es5 for compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
       "targets": { "node": 7 },
       "useBuiltIns": true
     }],
+    "es2015",
     "stage-0",
     "react"
   ]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.26.0",


### PR DESCRIPTION
I had minification error using create react app : https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify. Adding preset `es2015` fix it