### PR TITLE
Error callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,9 @@ class SequenceDiagram extends Component {
     if (!this.div) return;
 
     const { input, options } = this.props;
-    this.div.removeChild(this.div.children[0]);
+    if (this.div.children[0]){
+      this.div.removeChild(this.div.children[0]);
+    }
     try {
       const diagram = Diagram.parse(input);
       diagram.drawSVG(this.div, options);

--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,40 @@ class SequenceDiagram extends Component {
 
     const { input, options } = this.props;
     this.div.removeChild(this.div.children[0]);
-    const diagram = Diagram.parse(input);
-    diagram.drawSVG(this.div, options)
+    try {
+      const diagram = Diagram.parse(input);
+      diagram.drawSVG(this.div, options);
+    } catch(err) {
+     this.processError(err);
+    }
   }
 
   componentDidMount() {
     const { input, options } = this.props;
-    const diagram = Diagram.parse(input);
-    if (this.div) {
-      diagram.drawSVG(this.div, options)
+    try {
+      const diagram = Diagram.parse(input);
+      if (this.div) {
+        diagram.drawSVG(this.div, options)
+      }
+    } catch(err) {
+      this.processError(err);
+    }
+  }
+
+  processError(err) {
+    //use same annotation object as https://bramp.github.io/js-sequence-diagrams/
+    var annotation = {
+      type: "error", // also warning and information
+      column: 0,
+      row: 0,
+      text: err.message
+    };
+    if (err instanceof Diagram.ParseError) {
+      annotation.row    = err.loc.first_line - 1;
+      annotation.column = err.loc.first_column;
+    }
+    if (typeof this.props.onError === 'function') {
+      this.props.onError(annotation);
     }
   }
 


### PR DESCRIPTION
When diagram input parse fail, it would be nice to have a callback with the error. In case of the [official demo](https://bramp.github.io/js-sequence-diagrams/) it send the error into ace editor annotation

You can see a demo of this in [this tool I've developped](https://bertrandmartel.github.io/callflow-workshop/) which is using your lib

Sample usage is [here](https://github.com/bertrandmartel/callflow-workshop/blob/master/src/component/SessionContainer.js#L190)

Also checking that `this.div.children[0]` is not undefined in case parse have failed previously and no children actually exist